### PR TITLE
CIで利用するためyamlfmtを追加

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [20230822, 20231013]
+        version: [20231013, 20231018]
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [20230822, 20231013]
+        version: [20231013, 20231018]
     steps:
       - uses: actions/checkout@v3
 

--- a/20231018/Dockerfile
+++ b/20231018/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux && \
     go install mvdan.cc/gofumpt@latest && \
     go install github.com/daixiang0/gci@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2 && \
-    go install github.com/Yamashou/gqlgenc@v0.13.5 && \
+    go install github.com/Yamashou/gqlgenc@v0.15.1 && \
     go install github.com/gqlgo/nodecheck/cmd/nodecheck@v1.0.1 && \
     go install github.com/gqlgo/deprecatedquery/cmd/deprecatedquery@v0.0.3 && \
     go install github.com/gqlgo/optionalschema/cmd/optionalschema@v0.0.2 && \
@@ -38,7 +38,9 @@ RUN set -eux && \
     go install github.com/gqlgo/iddirective/cmd/iddirective@v0.0.1 && \
     go install github.com/builtbystack/nopermission/cmd/nopermission@v0.0.2 && \
     go install mvdan.cc/sh/v3/cmd/shfmt@latest && \
+    go install github.com/google/yamlfmt/cmd/yamlfmt@latest && \
     go install github.com/google/ko@v0.12.0 && \
+    go install github.com/sonatard/runenv@latest && \
     go install github.com/sonatard/runenv@latest && \
     rm -rf ${GOPATH}/src ${GOPATH}/pkg && \
     \

--- a/20231018/Dockerfile
+++ b/20231018/Dockerfile
@@ -41,7 +41,6 @@ RUN set -eux && \
     go install github.com/google/yamlfmt/cmd/yamlfmt@latest && \
     go install github.com/google/ko@v0.12.0 && \
     go install github.com/sonatard/runenv@latest && \
-    go install github.com/sonatard/runenv@latest && \
     rm -rf ${GOPATH}/src ${GOPATH}/pkg && \
     \
     # Artifact RegistryにPushするための認証設定


### PR DESCRIPTION
https://github.com/builtbystack/appify-server/pull/3373 で利用したいためyamlfmtを追加

https://github.com/builtbystack/appify-server/pull/3373#pullrequestreview-1683837038 を見て、yamlfmtを見たところ、Lintとしても実行できそうだったため、フォーマットとLintが統一できるメリットを取るためにyamlfmtに寄せようと考えている。

https://github.com/google/yamlfmt/blob/main/docs/command-usage.md#lint

そのため、このPRではyamllintを入れていない。