### PR TITLE
依存ツールにhammerを追加

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [20231109, 20231116]
+        version: [20231116, 20231127]
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [20231109, 20231116]
+        version: [20231116, 20231127]
     steps:
       - uses: actions/checkout@v3
 

--- a/20231127/Dockerfile
+++ b/20231127/Dockerfile
@@ -30,6 +30,7 @@ RUN set -eux && \
     go install mvdan.cc/gofumpt@latest && \
     go install github.com/daixiang0/gci@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2 && \
+    go install github.com/99designs/gqlgen@v0.17.40 && \
     go install github.com/Yamashou/gqlgenc@v0.16.0 && \
     go install github.com/gqlgo/nodecheck/cmd/nodecheck@v1.0.1 && \
     go install github.com/gqlgo/deprecatedquery/cmd/deprecatedquery@v0.0.3 && \
@@ -37,6 +38,7 @@ RUN set -eux && \
     go install github.com/gqlgo/operationname/cmd/operationname@v0.0.1 && \
     go install github.com/gqlgo/iddirective/cmd/iddirective@v0.0.1 && \
     go install github.com/builtbystack/nopermission/cmd/nopermission@v0.0.2 && \
+    go install github.com/daichirata/hammer@latest && \
     go install mvdan.cc/sh/v3/cmd/shfmt@latest && \
     go install github.com/google/yamlfmt/cmd/yamlfmt@latest && \
     go install github.com/google/ko@v0.12.0 && \


### PR DESCRIPTION
- ERPの開発をしているときにMainのSchemaがSpannerに適用されておらずにエラーになった
- 発見までの時間はかからなかったがMainが通らない状態は避けたい
- hammerにはdiffを取る機能があるのでそのうちPRのSchemaがmainに反映されていない場合警告するCIを作りたい